### PR TITLE
Teleposer fixes

### DIFF
--- a/src/main/java/wayoftime/bloodmagic/BloodMagic.java
+++ b/src/main/java/wayoftime/bloodmagic/BloodMagic.java
@@ -162,6 +162,10 @@ public class BloodMagic {
         for (String value : ConfigManager.COMMON.wellOfSuffering.get()) {
             api.getBlacklist().addWellOfSuffering(new ResourceLocation(value));
         }
+
+        for (String value : ConfigManager.COMMON.teleposer.get()) {
+            api.getBlacklist().addTeleposer(ForgeRegistries.BLOCKS.getValue(new ResourceLocation(value)));
+        }
     }
 
     private void registerRecipes(RegisterEvent event) {

--- a/src/main/java/wayoftime/bloodmagic/ConfigManager.java
+++ b/src/main/java/wayoftime/bloodmagic/ConfigManager.java
@@ -35,14 +35,22 @@ public class ConfigManager
 	public static class CommonConfig
 	{
 		public final ConfigValue<List<? extends String>> wellOfSuffering;
+		public final ConfigValue<List<? extends String>> teleposer;
+
 		public final ForgeConfigSpec.IntValue sacrificialDaggerConversion;
 		public final ConfigValue<List<? extends String>> sacrificialValues;
 		public final ForgeConfigSpec.BooleanValue makeDungeonRitualCreativeOnly;
 
+//		Edit BloodMagic.handleConfigValues to actually capture the new config
 		CommonConfig(ForgeConfigSpec.Builder builder)
 		{
-			builder.comment("Stops the listed entities from being used in the Well of Suffering.", "Use the registry name of the entity. Vanilla entities do not require the modid.").push("Blacklist");
+			builder.comment("Blacklist configuration").push("blacklist");
+
+			builder.comment("Stops the listed entities from being used in the Well of Suffering.", "Use the registry name of the entity. Vanilla entities do not require the modid.");
 			wellOfSuffering = builder.defineList("wellOfSuffering", ImmutableList.of(), obj -> true);
+
+			builder.comment("Stops the listed blocks from being teleported with teleposers", "Use the registry name of the entity. Vanilla blocks do not require the modid.");
+			teleposer = builder.defineList("teleposer", ImmutableList.of(), obj -> true);
 
 			builder.pop();
 

--- a/src/main/java/wayoftime/bloodmagic/common/tile/TileTeleposer.java
+++ b/src/main/java/wayoftime/bloodmagic/common/tile/TileTeleposer.java
@@ -196,14 +196,15 @@ public class TileTeleposer extends TileInventory implements MenuProvider, Comman
 	private SoulNetwork getNetwork()
 	{
 		ItemStack focusStack = this.getItem(FOCUS_SLOT);
-		try {
-			if (!focusStack.isEmpty() && focusStack.getItem() instanceof ITeleposerFocus) {
-				return NetworkHelper.getSoulNetwork(((ITeleposerFocus) focusStack.getItem()).getBinding(focusStack));
-			}
-		}catch(NullPointerException e) {
-			return null;
+
+		if (!focusStack.isEmpty() && focusStack.getItem() instanceof ITeleposerFocus) {
+			if (((ITeleposerFocus) focusStack.getItem()).getBinding(focusStack) == null)
+				return null;
+			return NetworkHelper.getSoulNetwork(((ITeleposerFocus) focusStack.getItem()).getBinding(focusStack));
 		}
-        return null;
+
+		return null;
+
     }
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/util/Utils.java
+++ b/src/main/java/wayoftime/bloodmagic/util/Utils.java
@@ -46,6 +46,8 @@ import wayoftime.bloodmagic.api.compat.IDemonWillViewer;
 import wayoftime.bloodmagic.common.tile.TileInventory;
 import wayoftime.bloodmagic.util.helper.InventoryHelper;
 import wayoftime.bloodmagic.util.helper.NBTHelper;
+import wayoftime.bloodmagic.impl.BloodMagicAPI;
+
 
 public class Utils
 {
@@ -193,6 +195,9 @@ public class Utils
 
 		BlockState initialState = initialWorld.getBlockState(initialPos);
 		BlockState finalState = finalWorld.getBlockState(finalPos);
+
+		if(BloodMagicAPI.INSTANCE.getBlacklist().getTeleposer().contains(initialState) || BloodMagicAPI.INSTANCE.getBlacklist().getTeleposer().contains(finalState))
+			return false;
 
 		if ((initialState.getBlock().equals(Blocks.AIR) && finalState.getBlock().equals(Blocks.AIR)) || initialState.getBlock() instanceof NetherPortalBlock || finalState.getBlock() instanceof NetherPortalBlock)
 			return false;


### PR DESCRIPTION
Cleaned up teleposer and added blacklist to the config

Example Blacklist config below
```
[blacklist]
        .....
	
        #Stops the listed blocks from being teleported with teleposers
	#Use the registry name of the entity. Vanilla blocks do not require the modid.
	teleposer = ["dirt", "stone", "spawner", "bloodmagic:altar"]

.....
```